### PR TITLE
SpringBootバージョンアップ

### DIFF
--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: e2e-testing
+description: 起動中のアプリケーションに対してcurlでE2Eデグレチェックを実行するスキル。全エンドポイントにリクエストを送り、ステータスコード・レスポンス構造を検証する。「E2Eテスト」「デグレチェック」「動作確認」「エンドポイント確認」「curlでテスト」などのリクエスト時に使用。
+---
+
+# E2Eデグレチェック
+
+curlでアプリケーションの全エンドポイントにリクエストし、デグレッションがないか確認する。
+
+## 前提条件
+
+- アプリケーションが起動済みであること
+- デフォルトポート: `8080`
+- 起動コマンド: `./gradlew bootRun`
+
+## 実行手順
+
+### 1. ヘルスチェック
+
+まずアプリが起動しているか確認する。
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/actuator/health
+```
+
+- 期待: `200`
+- 起動していない場合はユーザーに起動を促す
+
+### 2. 全エンドポイントのデグレチェック
+
+以下を順にBashツールで実行し、結果を検証する。
+
+#### GET /v1/sample
+
+```bash
+curl -s -w "\n%{http_code}" http://localhost:8080/v1/sample
+```
+
+**検証項目:**
+- ステータスコード: `200`
+- レスポンスにJSONキー `key` が存在すること
+
+#### GET /v1/todo
+
+```bash
+curl -s -w "\n%{http_code}" http://localhost:8080/v1/todo
+```
+
+**検証項目:**
+- ステータスコード: `200`
+- レスポンスにJSONキー `id` (数値) と `name` (文字列) が存在すること
+
+#### GET /v1/httpbin
+
+```bash
+curl -s -w "\n%{http_code}" http://localhost:8080/v1/httpbin
+```
+
+**検証項目:**
+- ステータスコード: `200`
+- レスポンスにJSONキー `origin` と `url` が存在すること
+
+#### GET /v1/sampleError
+
+```bash
+curl -s -w "\n%{http_code}" http://localhost:8080/v1/sampleError
+```
+
+**検証項目:**
+- ステータスコード: `500`
+- レスポンスにJSONキー `code` (値: `1`) と `message` が存在すること
+
+### 3. 結果レポート
+
+全テスト完了後、以下の形式で結果を報告する。
+
+```
+## E2Eデグレチェック結果
+
+| エンドポイント | ステータス | レスポンス検証 | 結果 |
+|--------------|----------|-------------|------|
+| GET /actuator/health | 200 | - | OK |
+| GET /v1/sample | 200 | key存在 | OK |
+| GET /v1/todo | 200 | id, name存在 | OK |
+| GET /v1/httpbin | 200 | origin, url存在 | OK |
+| GET /v1/sampleError | 500 | code=1, message存在 | OK |
+
+全 5/5 テスト OK - デグレなし
+```
+
+失敗があった場合は、期待値と実際の値の差分を明示する。
+
+## 注意事項
+
+- `/v1/todo` と `/v1/httpbin` は外部API（JSONPlaceholder, httpbin.org）に依存するため、外部API障害時は失敗する可能性がある
+- 外部API起因の失敗は、レスポンスの内容からアプリ側の問題か外部API側の問題かを切り分けて報告する

--- a/.claude/skills/e2e-testing/references/api-endpoints.md
+++ b/.claude/skills/e2e-testing/references/api-endpoints.md
@@ -1,0 +1,24 @@
+# API エンドポイント一覧
+
+## アプリケーション
+
+| メソッド | パス | 期待ステータス | レスポンスキー |
+|---------|------|-------------|-------------|
+| GET | `/v1/sample` | 200 | `key` |
+| GET | `/v1/todo` | 200 | `id`, `name` |
+| GET | `/v1/httpbin` | 200 | `origin`, `url` |
+| GET | `/v1/sampleError` | 500 | `code` (=1), `message` |
+
+## 管理
+
+| メソッド | パス | 期待ステータス |
+|---------|------|-------------|
+| GET | `/actuator/health` | 200 |
+| GET | `/actuator/prometheus` | 200 |
+
+## 外部API依存
+
+| エンドポイント | 依存先 |
+|-------------|-------|
+| `/v1/todo` | `https://jsonplaceholder.typicode.com/posts/1`, `/posts/78` |
+| `/v1/httpbin` | `https://httpbin.org/get` |

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,6 @@ test {
 apply plugin: 'checkstyle'
 
 checkstyle {
-    toolVersion '10.9.3'
-    configFile file('./config/google_checks.xml')
+    toolVersion = '10.9.3'
+    configFile = file('./config/google_checks.xml')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
     // swagger
     // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webflux-ui
-    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:3.0.1'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -40,10 +40,10 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // https://mvnrepository.com/artifact/net.logstash.logback/logstash-logback-encoder
-    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+    implementation 'net.logstash.logback:logstash-logback-encoder:9.0'
 
     // https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-prometheus
-    implementation 'io.micrometer:micrometer-registry-prometheus:1.12.3'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // ログのトレーシング
     implementation 'io.micrometer:micrometer-tracing'

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,17 @@
 plugins {
-    id 'org.springframework.boot' version '3.2.3'
-    id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.springframework.boot' version '4.0.2'
+    id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
 }
 
 group = 'com.example'
 version = '0.1.0-SNAPSHOT'
-sourceCompatibility = '18'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
 
 configurations {
     compileOnly {

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-webclient'
 
     // swagger
     // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webflux-ui
@@ -50,6 +51,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webclient-test'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,2 @@
 [tools]
-gradle = "8.14.3"
 java = "temurin-25.0.2+10.0.LTS"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 gradle = "8.14.3"
-java = "temurin-23"
+java = "temurin-25.0.2+10.0.LTS"


### PR DESCRIPTION
## 概要

## 修正内容
- SpringBootのバージョンを4.0.2に上げる
  - `WebClient.Builder`が仕様変更により自動的にDIされなくなったので、新しいライブラリ追加
- Javaのバージョンを25に上げる
- Gradleのバージョンを9.3.1に上げる
- 各種ライブラリのバージョンアップ

## 備考
- https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide
- https://github.com/spring-projects/spring-boot/issues/48293
- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webflux-ui
- https://mvnrepository.com/artifact/net.logstash.logback/logstash-logback-encoder
- https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-prometheus